### PR TITLE
Fixed documentation of eval command needed for shell config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Then add the following to your shell config at the end:
 
 ```
 export PATH="$HOME/.nodenv/bin:$PATH"
-eval "(nodenv init -)"
+eval "$(nodenv init -)"
 ```
 
 ## Usage


### PR DESCRIPTION
The previous version of the command was causing the init statement not be properly evaluated. These command was pulled from the command `nodenv init`