### PR TITLE
Allow compile on OSes where python2.5 is default

### DIFF
--- a/libexec/nodenv-install
+++ b/libexec/nodenv-install
@@ -42,7 +42,7 @@ if [ "$compile" = "--source" ]; then
     curl -s -f "$alt_download" > /tmp/node-$version.tar.gz) && \
     tar zxf /tmp/node-$version.tar.gz -C /tmp && \
     cd /tmp/node-$version && \
-    (./configure --prefix="$version_dir" && make && make install) 2>&1 > /tmp/nodenv-install-$version.log && \
+    ($PYTHON ./configure --prefix="$version_dir" && make && make install) 2>&1 > /tmp/nodenv-install-$version.log && \
     rm /tmp/node-$version.tar.gz && \
     rm -rf /tmp/node-$version || \
     {


### PR DESCRIPTION
On CentOS 5, python 2.5 is default with glibc 2.5. This requires a custom compilation of python.

`./configure` needs to be called by python2.6 or python2.7 to compile. `make` already picks up the environment variable