### PR TITLE
Added support to install io.js versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,28 @@ Some useful nodenv commands are:
 See `nodenv help <command>' for information on a specific command.
 ```
 
+### Usage with Node.js
+```
+# Use 0.8 versions
+nodenv install v0.8.28
+
+# Use 0.10 versions
+nodenv install v0.10.38
+
+# Use 0.12 versions
+nodenv install v0.12.2
+
+```
+
+### Usage with io.js
+```
+# Use any io.js version
+nodenv install iojs-v1.6.4
+
+# You can also install the latest version of io.js
+nodenv install iojs
+```
+
 ## Credits
 
 This library was heavily, heavily, heavily inspired by

--- a/libexec/nodenv-install
+++ b/libexec/nodenv-install
@@ -79,12 +79,18 @@ else
   fi
 
   # URL to download from
-  download="http://nodejs.org/dist/${version}/node-${version}-${platform}-${arch}.tar.gz"
+  if [[ $1 == iojs-* ]];then
+    ioversion=${1##*-}
+    download="https://iojs.org/dist/${ioversion}/iojs-${ioversion}-${platform}-${arch}.tar.gz"
+  else
+    download="http://nodejs.org/dist/${version}/node-${version}-${platform}-${arch}.tar.gz"
+  fi
 
   # Can't get too clever here
   set +e
 
   # Download binary tarball and install
+  echo $download
   curl -s -f "$download" > /tmp/node-$version.tar.gz && \
     tar zxf /tmp/node-$version.tar.gz --strip-components 1 && \
     rm /tmp/node-$version.tar.gz || \

--- a/libexec/nodenv-install
+++ b/libexec/nodenv-install
@@ -31,6 +31,12 @@ if [ "$1" = "--complete" ]; then
   exit 0
 fi
 
+# Sugar for install latest version of iojs
+if [[ $1 == iojs ]]; then
+  iolatest=$(curl -s -f https://iojs.org/dist/index.tab | head -n 2 | awk 'NR==2{print $1}')
+  set -- "iojs-$iolatest" "${@:2}"
+fi
+
 # Pull the desired version out of ARGV
 version="$1"
 version_dir="$NODENV_ROOT/versions/$version"

--- a/libexec/nodenv-install
+++ b/libexec/nodenv-install
@@ -47,8 +47,17 @@ cd "$version_dir"
 
 if [ "$compile" = "--source" ]; then
   # Let's fetch the source and build it
-  download="http://nodejs.org/dist/${version}/node-${version}.tar.gz"
-  alt_download="http://nodejs.org/dist/node-${version}.tar.gz"
+  if [[ $1 == iojs-* ]]; then
+    ioversion=${1##*-}
+    work_dir="/tmp/iojs-$ioversion"
+    download="https://iojs.org/dist/${ioversion}/iojs-${ioversion}.tar.gz"
+    # There is no tarballs at alternatives places on io.js project, so try again!
+    alt_download="https://iojs.org/dist/${ioversion}/iojs-${ioversion}.tar.gz"
+  else
+    download="http://nodejs.org/dist/${version}/node-${version}.tar.gz"
+    alt_download="http://nodejs.org/dist/node-${version}.tar.gz"
+    work_dir="/tmp/node-$version"
+  fi
 
   # Can't get too clever here
   set +e
@@ -57,13 +66,13 @@ if [ "$compile" = "--source" ]; then
   (curl -s -f "$download" > /tmp/node-$version.tar.gz || \
     curl -s -f "$alt_download" > /tmp/node-$version.tar.gz) && \
     tar zxf /tmp/node-$version.tar.gz -C /tmp && \
-    cd /tmp/node-$version && \
+    cd $work_dir && \
     ($PYTHON ./configure --prefix="$version_dir" && make && make install) 2>&1 > /tmp/nodenv-install-$version.log && \
     rm /tmp/node-$version.tar.gz && \
-    rm -rf /tmp/node-$version || \
+    rm -rf $work_dir || \
     {
       cd $OLDPWD
-      rm -rf "$version_dir" /tmp/node-$version.tar.gz /tmp/node-$version
+      rm -rf "$version_dir" /tmp/node-$version.tar.gz $work_dir
 
       echo "nodenv: installation of $version from source failed" >&2
       exit 1
@@ -90,7 +99,6 @@ else
   set +e
 
   # Download binary tarball and install
-  echo $download
   curl -s -f "$download" > /tmp/node-$version.tar.gz && \
     tar zxf /tmp/node-$version.tar.gz --strip-components 1 && \
     rm /tmp/node-$version.tar.gz || \


### PR DESCRIPTION
Hi

I just modify a bit the `nodenv-install` script to understand `iojs-*` versions and could be installed. Also did that for the compilation from sources using `--source` flag. And as final touch I added a little sugar to install latest version of io.js just running `nodenv install iojs`

Let me know if there are any styling or any other thing to fix.