### PR TITLE
[init] show instructions to configure PATH correctly

### DIFF
--- a/libexec/nodenv-init
+++ b/libexec/nodenv-init
@@ -66,6 +66,7 @@ if [ -z "$print" ]; then
   { echo "# Load nodenv automatically by adding"
     echo "# the following to ${profile}:"
     echo
+    echo 'export PATH="'${NODENV_ROOT}'/bin:$PATH"'
     echo 'eval "$(nodenv init -)"'
     echo
   } >&2


### PR DESCRIPTION
As the configured `PATH` should be included on the configuration of the shell, is better show the message when `nodenv init`

Someone could test it add give me a +1 if works?